### PR TITLE
Add the ability to draw a line as legend symbol

### DIFF
--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -360,6 +360,9 @@ module.exports = function(Chart) {
 
 						// Draw pointStyle as legend symbol
 						Chart.canvasHelpers.drawPoint(ctx, legendItem.pointStyle, radius, centerX, centerY);
+					} else if (opts.labels && opts.labels.useLineStyle) {
+						// Draw line as legend symbol
+    					ctx.strokeRect(x, y + fontSize / 2, boxWidth, 0);
 					} else {
 						// Draw box as legend symbol
 						if (!isLineWidthZero) {


### PR DESCRIPTION
This was requested by a client and I found a solution here http://stackoverflow.com/questions/39155400/legends-for-line-charts-in-chart-js and noticed there was no PR about it.